### PR TITLE
[solr] fix: use nindent instead of indent for correct yaml indentation

### DIFF
--- a/charts/solr/Chart.yaml
+++ b/charts/solr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: solr
-version: 3.0.2
+version: 3.0.3
 appVersion: 8.7.0
 description: "A helm chart to install Apache Solr: http://lucene.apache.org/solr/"
 keywords:

--- a/charts/solr/templates/statefulset.yaml
+++ b/charts/solr/templates/statefulset.yaml
@@ -20,13 +20,13 @@ spec:
         {{- include "common.labels.standard" $ | nindent 8 }}
         app.kubernetes.io/component: "server"
       annotations:
-        {{- toYaml .Values.podAnnotations | indent 8 }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
     spec:
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
       {{- end }}
       affinity:
-        {{- tpl (toYaml .Values.affinity) . | indent 8 }}
+        {{- tpl (toYaml .Values.affinity) . | nindent 8 }}
       {{- if $.Values.securityContext.enabled }}
       tolerations:
         {{- include "common.tplvalues.render" (dict "value" $.Values.tolerations "context" $) | nindent 8 }}


### PR DESCRIPTION
**Description of the change**
Use `nindent` instead of `indent`

**Benefits**
Allows the usage of the `affinity` config

**Applicable issues**
  - fixes #22 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[chart-name] Update depedency`)
