### PR TITLE
[solr] Add option to use an existing PersistentVolumeClaim

### DIFF
--- a/charts/solr/Chart.yaml
+++ b/charts/solr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: solr
-version: 3.1.0
+version: 3.2.0
 appVersion: 8.7.0
 description: "A helm chart to install Apache Solr: http://lucene.apache.org/solr/"
 keywords:

--- a/charts/solr/README.md
+++ b/charts/solr/README.md
@@ -112,7 +112,7 @@ The following table shows the configuration options for the Solr helm chart:
 | `volumeClaimTemplates.storageClassName`       | The name of the storage class for the Solr PVC | `""` |
 | `volumeClaimTemplates.storageSize`            | The size of the PVC | `20Gi` |
 | `volumeClaimTemplates.accessModes`            | The access mode of the PVC| `["ReadWriteOnce"]` |
-| `existingVolumeClaim`                         | Use an existing PersistentVolumeClaim instead of the dynamic PVC provisioning of the StatefulSet | `""` |
+| `existingVolumeClaim`                         | Use an existing PersistentVolumeClaim instead of the `volumeClaimTemplates` spec of the StatefulSet | `""` |
 | `tls.enabled`                                 | Whether to enable TLS, requires `tls.certSecret.name` to be set to a secret containing cert details, see README for details | `false` |
 | `tls.wantClientAuth`                          | Whether Solr wants client authentication | `false` |
 | `tls.needClientAuth`                          | Whether Solr requires client authentication | `false` |

--- a/charts/solr/README.md
+++ b/charts/solr/README.md
@@ -112,6 +112,7 @@ The following table shows the configuration options for the Solr helm chart:
 | `volumeClaimTemplates.storageClassName`       | The name of the storage class for the Solr PVC | `""` |
 | `volumeClaimTemplates.storageSize`            | The size of the PVC | `20Gi` |
 | `volumeClaimTemplates.accessModes`            | The access mode of the PVC| `["ReadWriteOnce"]` |
+| `existingVolumeClaim`                         | Use an existing PersistentVolumeClaim instead of the dynamic PVC provisioning of the StatefulSet | `""` |
 | `tls.enabled`                                 | Whether to enable TLS, requires `tls.certSecret.name` to be set to a secret containing cert details, see README for details | `false` |
 | `tls.wantClientAuth`                          | Whether Solr wants client authentication | `false` |
 | `tls.needClientAuth`                          | Whether Solr requires client authentication | `false` |

--- a/charts/solr/templates/statefulset.yaml
+++ b/charts/solr/templates/statefulset.yaml
@@ -226,6 +226,11 @@ spec:
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
+        {{- if .Values.existingVolumeClaim }}
+        - name: {{ include "solr.pvc-name" . }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.existingVolumeClaim }}   
+        {{- else }}    
   volumeClaimTemplates:
     - metadata:
         name: {{ include "solr.pvc-name" . }}
@@ -240,3 +245,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.volumeClaimTemplates.storageSize }}
+        {{- end }}

--- a/charts/solr/values.yaml
+++ b/charts/solr/values.yaml
@@ -129,6 +129,7 @@ podAnnotations: {}
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##
 # schedulerName:
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
@@ -140,6 +141,12 @@ volumeClaimTemplates:
   ## PersistentVolumeClaim size
   ##
   storageSize: 20Gi
+
+## Use an existing PersistentVolumeClaim
+## For example: Share a volume between the pods using EFS CSI driver
+## ref: https://github.com/kubernetes-sigs/aws-efs-csi-driver
+##
+existingVolumeClaim: ""
 
 ## Pod Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
**Description of the change**
New value added to use an existing PersistentVolumeClaim instead of the `volumeClaimTemplates` spec of the StatefulSet

**Benefits**
Possibility to use a shared PVC, using the EFS CSI driver for instance (ref: https://github.com/kubernetes-sigs/aws-efs-csi-driver)

**Possible drawbacks**
Any limitations

**Applicable issues**
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[chart-name] Update depedency`)
